### PR TITLE
fix Repo.WithRevision()

### DIFF
--- a/hub/repo.go
+++ b/hub/repo.go
@@ -78,8 +78,8 @@ func (r *Repo) WithType(repoType RepoType) *Repo {
 }
 
 // WithRevision sets the revision to use for this Repo, defaults to "main", but can be set to a commit-hash value.
-func (r *Repo) WithRevision(repoType RepoType) *Repo {
-	r.repoType = repoType
+func (r *Repo) WithRevision(revision string) *Repo {
+	r.revision = revision
 	return r
 }
 


### PR DESCRIPTION
It looks like a copy/paste error from `WithType()`

This PR updates `WithRevision()` to set `Repo.revision` instead of `Repo.repoType` and some manual testing shows it working as I would expect. Branch names work, and so does a full or partial commit hash.

