### PR TITLE
fix: BertNormalizer/Lowercase offset tracking under-counts multi-byte UTF-8 output

### DIFF
--- a/tokenizers/hftokenizer/hftokenizer.go
+++ b/tokenizers/hftokenizer/hftokenizer.go
@@ -449,14 +449,22 @@ func (t *Tokenizer) applyNormalizerWithSpans(text string, n *Normalizer) (string
 
 	switch n.Type {
 	case "Lowercase":
-		// Lowercase preserves character positions (1:1 mapping)
+		// Lowercase preserves character positions (1:1 mapping), but the
+		// lowercased form of a single rune can occupy a different number of
+		// BYTES than the original (e.g. "É" (2 bytes) -> "é" (2 bytes) is
+		// fine, but some runes lowercase to a differently-sized UTF-8
+		// encoding). offsets is indexed by byte position in `normalized`
+		// (len(normalized) is a byte count), so it must be filled one entry
+		// per output BYTE, not per output RUNE — iterating rune-by-rune
+		// under-fills it for any multi-byte lowercased character, leaving
+		// trailing entries at their zero value instead of a real offset.
 		normalized := strings.ToLower(text)
 		offsets := make([]int, len(normalized))
 		origPos := 0
 		normPos := 0
 		for _, r := range text {
-			lowerRunes := []rune(strings.ToLower(string(r)))
-			for range lowerRunes {
+			lowerStr := strings.ToLower(string(r))
+			for range len(lowerStr) {
 				if normPos < len(offsets) {
 					offsets[normPos] = origPos
 					normPos++
@@ -483,7 +491,14 @@ func (t *Tokenizer) applyNormalizerWithSpans(text string, n *Normalizer) (string
 				result.WriteRune(' ')
 				offsets = append(offsets, origPos)
 				result.WriteRune(r)
-				offsets = append(offsets, origPos)
+				// r itself may be a multi-byte rune (CJK characters are
+				// typically 3 bytes in UTF-8) — append one offset entry per
+				// BYTE written, not one entry for the whole rune. See the
+				// "else" branch below for the same class of bug and a
+				// fuller explanation.
+				for range runeLen {
+					offsets = append(offsets, origPos)
+				}
 				result.WriteRune(' ')
 				offsets = append(offsets, origPos)
 			} else if isWhitespace(r) {
@@ -498,7 +513,23 @@ func (t *Tokenizer) applyNormalizerWithSpans(text string, n *Normalizer) (string
 				if n.Lowercase {
 					s = strings.ToLower(s)
 				}
-				for range s {
+				// offsets is a per-BYTE map (result.String() is indexed by
+				// byte, and downstream code treats offsets[i] as the
+				// original-text position of normalized BYTE i). `for range
+				// s` iterates s's RUNES, not its bytes, so for any `s` that
+				// passes through as (or becomes) a multi-byte UTF-8
+				// sequence — every accented Latin character on a cased
+				// model that does not strip accents or lowercase, e.g.
+				// á/é/í/ó/ú/ñ/ã/ç/ă/â/î/ș/ț/ü/ö/ä — this appended exactly
+				// one offset entry while result.WriteString(s) wrote 2+
+				// bytes, under-filling offsets by one per such character.
+				// The deficit compounds across the string until downstream
+				// code indexes past the now-too-short offsets slice
+				// (observed live as `slice bounds out of range` panics on
+				// Romanian/Spanish/Portuguese/CJK-heavy text). Iterate by
+				// byte count instead so offsets always has exactly
+				// len(result.String()) entries.
+				for range len(s) {
 					offsets = append(offsets, origPos)
 				}
 				result.WriteString(s)

--- a/tokenizers/hftokenizer/hftokenizer_offsets_test.go
+++ b/tokenizers/hftokenizer/hftokenizer_offsets_test.go
@@ -1,0 +1,177 @@
+package hftokenizer
+
+import "testing"
+
+// These tests guard against a byte/rune accounting bug in
+// applyNormalizerWithSpans: the returned offsets slice must have exactly
+// one entry per BYTE of the returned normalized string, because downstream
+// code (encodeCore, preTokenizeWithSpans, tokenizeWordWithSpans) treats
+// offsets[i] as a direct byte-slice index into the normalized text.
+//
+// The bug: for a "BertNormalizer" configured like a real cased model
+// (dslim/bert-base-NER's actual tokenizer.json: strip_accents=null,
+// lowercase=false, handle_chinese_chars=true — every accented Latin
+// character and CJK character passes through UNCHANGED or is re-emitted
+// as-is), the code appended exactly ONE offset entry per RUNE (`for range
+// s` / one `WriteRune(r)` call) while writing potentially MULTIPLE bytes
+// (`result.WriteString(s)` / a multi-byte `WriteRune(r)`). Every
+// multi-byte character under-fills offsets by one entry relative to
+// len(result). The deficit compounds across the string until downstream
+// code indexes offsets past its (too-short) length, which is the direct
+// mechanism behind the "slice bounds out of range" panics observed live in
+// github.com/knights-analytics/hugot-based NER pipelines on
+// Romanian/Spanish/Portuguese/CJK-heavy text.
+
+// bertNERNormalizer mirrors the ACTUAL normalizer block from the
+// optimum/bert-base-NER tokenizer.json used in production by
+// baditaflorin/go_named_entity_recognizer: a cased model that neither
+// strips accents nor lowercases.
+func bertNERNormalizer() *Normalizer {
+	return &Normalizer{
+		Type:               "BertNormalizer",
+		CleanText:          true,
+		HandleChineseChars: true,
+		StripAccents:       nil, // exactly matches optimum/bert-base-NER's tokenizer.json: "strip_accents": null
+		Lowercase:          false,
+	}
+}
+
+// assertOffsetsCoverBytes is the core invariant this bug violates: offsets
+// must have exactly one entry per byte of the normalized output.
+func assertOffsetsCoverBytes(t *testing.T, label, input, normalized string, offsets []int) {
+	t.Helper()
+	if len(offsets) != len(normalized) {
+		t.Fatalf("%s: len(offsets)=%d != len(normalized)=%d (input=%q, normalized=%q, offsets=%v)",
+			label, len(offsets), len(normalized), input, normalized, offsets)
+	}
+	// Every offset must be a valid byte index into the ORIGINAL input
+	// (or, for the identity case, equal to len(input) is never expected
+	// here since offsets record start positions of source runes).
+	for i, off := range offsets {
+		if off < 0 || off > len(input) {
+			t.Fatalf("%s: offsets[%d]=%d out of range for input length %d (input=%q)", label, i, off, len(input), input)
+		}
+	}
+}
+
+func TestApplyNormalizerWithSpans_BertNormalizer_AccentedLatin(t *testing.T) {
+	tok := &Tokenizer{}
+	n := bertNERNormalizer()
+
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"single 2-byte accented char", "Ștefan"},
+		{"name with multiple accents", "Ștefan Popescu"},
+		{"german umlaut", "München"},
+		{"spanish tilde and accents", "Múnich Íñigo"},
+		{"portuguese", "São Paulo Brasília"},
+		{"romanian full sentence", "Ștefan Popescu s-a născut în România și a studiat la Universitatea din București."},
+		{"spanish full sentence", "El presidente de España visitó Múnich la semana pasada junto a Íñigo Fernández."},
+		{"portuguese full sentence", "O diretor da empresa em São Paulo anunciou investimentos em Brasília e no Porto."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			normalized, offsets := tok.applyNormalizerWithSpans(tc.text, n)
+			assertOffsetsCoverBytes(t, tc.name, tc.text, normalized, offsets)
+		})
+	}
+}
+
+func TestApplyNormalizerWithSpans_BertNormalizer_ChineseChars(t *testing.T) {
+	tok := &Tokenizer{}
+	n := bertNERNormalizer()
+
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"cjk only", "习近平"},
+		{"cjk sentence", "习近平主席访问了北京大学并会见了马云和李彦宏。"},
+		{"mixed latin and cjk", "Tim Cook visited 北京 for Apple."},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			normalized, offsets := tok.applyNormalizerWithSpans(tc.text, n)
+			assertOffsetsCoverBytes(t, tc.name, tc.text, normalized, offsets)
+		})
+	}
+}
+
+// TestApplyNormalizerWithSpans_BertNormalizer_OffsetsResolveCorrectSubstring
+// goes one step further than byte-count parity: it confirms that for every
+// byte position in the normalized string, offsets[pos] actually points at
+// a byte position in the original text that is part of the SAME source
+// rune — i.e. the mapping is not just the right length, it is right.
+func TestApplyNormalizerWithSpans_BertNormalizer_OffsetsResolveCorrectSubstring(t *testing.T) {
+	tok := &Tokenizer{}
+	n := bertNERNormalizer()
+
+	text := "Ștefan Popescu vizitează Bucureşti."
+	normalized, offsets := tok.applyNormalizerWithSpans(text, n)
+	assertOffsetsCoverBytes(t, "resolve-substring", text, normalized, offsets)
+
+	// Since strip_accents=false and lowercase=false, BertNormalizer with
+	// clean text + no whitespace collapsing beyond ASCII space should
+	// reproduce the input verbatim (modulo whitespace normalization to a
+	// single ASCII space, which this input doesn't exercise).
+	if normalized != text {
+		t.Fatalf("expected byte-identical passthrough for a cased normalizer with no accent-stripping/lowercasing, got %q from %q", normalized, text)
+	}
+	// Every byte of a given source rune's output maps back to that rune's
+	// START byte position (matching the convention already used for the
+	// whitespace/Chinese-char branches, which assign the same origPos to
+	// every entry they append for one source rune) — NOT to its own byte
+	// index. Compute the expected start-of-rune position for every byte of
+	// the input independently (via utf8 rune boundaries) and compare.
+	wantStart := make([]int, len(text))
+	pos := 0
+	for _, r := range text {
+		n := len(string(r))
+		for k := 0; k < n; k++ {
+			wantStart[pos+k] = pos
+		}
+		pos += n
+	}
+	for i, off := range offsets {
+		if off != wantStart[i] {
+			t.Errorf("offsets[%d]=%d, want %d (should map to the start byte of the source rune covering output byte %d)", i, off, wantStart[i], i)
+		}
+	}
+}
+
+// TestApplyNormalizerWithSpans_Lowercase_MultiByteResult guards the same
+// class of bug in the "Lowercase" branch: offsets must be filled one entry
+// per output BYTE, not one per output RUNE, even though the offsets slice
+// itself is (correctly) pre-sized to len(normalized) bytes. Before the fix
+// this branch didn't panic (bounds-checked) but silently left trailing
+// entries at their zero value for any text containing multi-byte
+// lowercased characters, corrupting the offset mapping.
+func TestApplyNormalizerWithSpans_Lowercase_MultiByteResult(t *testing.T) {
+	tok := &Tokenizer{}
+	n := &Normalizer{Type: "Lowercase"}
+
+	cases := []string{
+		"MÜNCHEN",
+		"ÎNTÂLNIRE",
+		"São Paulo Ñandú",
+	}
+	for _, text := range cases {
+		t.Run(text, func(t *testing.T) {
+			normalized, offsets := tok.applyNormalizerWithSpans(text, n)
+			assertOffsetsCoverBytes(t, text, text, normalized, offsets)
+			// No trailing zero-valued (unfilled) entries once real content
+			// has already advanced origPos past 0: every offset actually
+			// present in the source should be non-decreasing.
+			for i := 1; i < len(offsets); i++ {
+				if offsets[i] < offsets[i-1] {
+					t.Errorf("offsets not monotonic at %d: offsets[%d]=%d < offsets[%d]=%d (likely an unfilled/zero-valued trailing entry)",
+						i, i, offsets[i], i-1, offsets[i-1])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`Tokenizer.applyNormalizerWithSpans` (`tokenizers/hftokenizer/hftokenizer.go`) returns `offsets[normalizedBytePos] = origBytePos` — one entry **per byte** of the normalized string. Callers (`encodeCore`, `preTokenizeWithSpans`, `tokenizeWordWithSpans`) index this slice directly as a byte-position map.

In the `"BertNormalizer"` case, the accent-stripping/lowercasing branch does:

```go
for range s {
    offsets = append(offsets, origPos)
}
result.WriteString(s)
```

`for range s` iterates the **runes** of `s`, appending one offset entry per rune, while `result.WriteString(s)` writes the **bytes** of `s`. For any `s` that passes through unchanged as a multi-byte UTF-8 sequence — every accented Latin character (á, é, í, ó, ú, ñ, ã, ç, ă, â, î, ș, ț, ü, ö, ä, ...) on a **cased** model that neither strips accents nor lowercases (e.g. a `bert-base-cased`-derived NER model, whose real `tokenizer.json` ships `"strip_accents": null, "lowercase": false`) — this under-fills `offsets` by exactly one entry relative to `len(result)`.

The same bug is present in the `HandleChineseChars` branch's `result.WriteRune(r)` call (CJK characters are typically 3 bytes in UTF-8, but only 1 offset entry is appended), and in the `"Lowercase"` case's `for range lowerRunes` loop — that one doesn't panic (it's bounds-checked against a correctly-byte-sized `offsets` slice) but silently leaves trailing entries at their zero value for any multi-byte lowercased character, corrupting the mapping instead of crashing on it.

The deficit compounds across the string. Once `len(offsets)` falls behind the byte length of the normalized text, downstream indexing into `offsets` by byte position runs past its length.

## Real-world impact

Reproduced directly against the actual `optimum/bert-base-NER` `tokenizer.json` (`strip_accents: null, lowercase: false, handle_chinese_chars: true`) via `github.com/knights-analytics/hugot`, in production use by `baditaflorin/go_named_entity_recognizer`. Every tested Romanian, Spanish, Portuguese, and CJK/Cyrillic sentence triggers:

```
runtime error: slice bounds out of range [:91] with length 87
```

silently downgrading every non-English NER request to a much weaker fallback engine (or panicking outright in callers with no recover()).

## The fix

Iterate by **byte count** instead of rune count when filling/appending offset entries, so `offsets` always has exactly one entry per byte of the transformed output:

- `for range s` → `for range len(s)` (the accent/lowercase branch)
- `result.WriteRune(r); offsets = append(offsets, origPos)` → append one entry per byte of `r`'s UTF-8 encoding (the Chinese-char branch)
- `for range lowerRunes` → `for range len(lowerStr)` (the `"Lowercase"` case)

## Tests

Adds `tokenizers/hftokenizer/hftokenizer_offsets_test.go`:
- Accented Latin text (single chars, names, full Romanian/Spanish/Portuguese sentences) — asserts `len(offsets) == len(normalized)`.
- CJK text (`HandleChineseChars` branch) — same invariant.
- A byte-identical-passthrough case that additionally verifies every offset entry resolves to the *correct* source rune, not just the right count.
- The `"Lowercase"` branch with multi-byte lowercased characters — asserts no unfilled (zero-valued / non-monotonic) trailing entries.

Verified these tests **fail** against the pre-fix code (confirmed via `git stash`) and **pass** after the fix. Full existing suite (`go test ./...`) passes with no regressions in the affected packages; the only two failures in the broader suite are pre-existing multi-GB model-download integration tests (`examples/kalmgemma3`, `models/transformer`) unrelated to this change and gated on local disk space, not on `tokenizers/hftokenizer`.

This is a text-offset correctness bug with no security/API-surface implications — the fix is scoped exactly to the byte/rune accounting, no refactoring.