### PR TITLE
safetensors: bounds-check tensor data_offsets before slicing

### DIFF
--- a/models/safetensors/iter.go
+++ b/models/safetensors/iter.go
@@ -189,7 +189,17 @@ func iterFromRepoDownload(backend compute.Backend, repo *hub.Repo, done <-chan s
 				return
 			}
 
-			readBuffer := fr.mmap[dataOffset+meta.DataOffsets[0] : dataOffset+meta.DataOffsets[1]]
+			// data_offsets are from the untrusted file header; validate they
+			// fall within the mapped data before slicing to avoid a
+			// slice-out-of-range panic on a crafted header.
+			tensorOffset := dataOffset + meta.DataOffsets[0]
+			tensorEnd := dataOffset + meta.DataOffsets[1]
+			if tensorOffset < 0 || tensorEnd < tensorOffset || tensorEnd > int64(len(fr.mmap)) {
+				reportErrFn(errors.Errorf("tensor %q data offsets [%d:%d] out of range for %d-byte data section", name, tensorOffset, tensorEnd, int64(len(fr.mmap))))
+				return
+			}
+
+			readBuffer := fr.mmap[tensorOffset:tensorEnd]
 
 			waitStart = time.Now()
 			select {

--- a/models/safetensors/reader.go
+++ b/models/safetensors/reader.go
@@ -100,6 +100,13 @@ func (mr *TensorReader) ReadTensor(backend compute.Backend, tensorName string) (
 		return nil, errors.Errorf("tensor shape %s expected %d bytes, but got %d bytes in file", shape, expectedBytes, tensorEnd-tensorOffset)
 	}
 
+	// data_offsets come from the (untrusted) file header, so validate they fall
+	// within the mapped data before slicing: otherwise a crafted header makes
+	// mr.mmapBuf[tensorOffset:tensorEnd] panic with a slice-out-of-range.
+	if tensorOffset < 0 || tensorEnd < tensorOffset || tensorEnd > int64(len(mr.mmapBuf)) {
+		return nil, errors.Errorf("tensor %q data offsets [%d:%d] out of range for %d-byte data section", tensorName, tensorOffset, tensorEnd, int64(len(mr.mmapBuf)))
+	}
+
 	readBuffer := mr.mmapBuf[tensorOffset:tensorEnd]
 
 	t, err := tensors.FromRaw(backend, 0, shape, readBuffer)

--- a/models/safetensors/reader_oob_test.go
+++ b/models/safetensors/reader_oob_test.go
@@ -1,0 +1,43 @@
+package safetensors
+
+import (
+	"strings"
+	"testing"
+)
+
+// A safetensors file header is untrusted input, and each tensor's data_offsets
+// come straight from it. ReadTensor sliced mr.mmapBuf[offset:end] using those
+// offsets after only checking that (end-start) matched the shape's byte size,
+// never that the offsets fell within the mapped data. A crafted header could
+// therefore point outside the buffer (or use a negative start) and panic the
+// reader with a slice-out-of-range. These tests ensure such offsets are
+// rejected with an error instead.
+func TestReadTensorRejectsOutOfRangeOffsets(t *testing.T) {
+	newReader := func(off [2]int64) *TensorReader {
+		return &TensorReader{
+			mmapBuf:    make([]byte, 16),
+			dataOffset: 0,
+			Header: &Header{Tensors: map[string]*TensorMetadata{
+				"evil": {Name: "evil", Dtype: "F32", Shape: []int{4}, DataOffsets: off},
+			}},
+		}
+	}
+	cases := map[string][2]int64{
+		"beyond-buffer": {1 << 40, 1<<40 + 16},
+		"negative":      {-16, 0},
+	}
+	for name, off := range cases {
+		t.Run(name, func(t *testing.T) {
+			tr := newReader(off)
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("ReadTensor panicked on %s offsets: %v", name, r)
+				}
+			}()
+			_, err := tr.ReadTensor(nil, "evil")
+			if err == nil || !strings.Contains(err.Error(), "out of range") {
+				t.Fatalf("expected out-of-range error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

A safetensors file header is untrusted input, and each tensor's `data_offsets` come straight from it. Both read paths then slice the mmap'd data using those offsets:

`models/safetensors/reader.go` (`ReadTensor`):
```go
tensorOffset := mr.dataOffset + meta.DataOffsets[0]
tensorEnd := mr.dataOffset + meta.DataOffsets[1]
if tensorEnd-tensorOffset != expectedBytes { ... }   // only checks the *difference*
readBuffer := mr.mmapBuf[tensorOffset:tensorEnd]
```

`models/safetensors/iter.go` (`IterTensors`) does the same slice with no check at all.

Neither verifies the offsets fall within the mapped data. The `end-start == expectedBytes` check is satisfiable while pointing anywhere, so a crafted header can declare `data_offsets` far beyond the buffer, or a negative start, and crash the reader:

```
runtime error: slice bounds out of range [:1099511627792] with capacity 16
runtime error: slice bounds out of range [-16:]
```

`ReadTensor` / `IterTensors` are the public API for loading tensors from an untrusted `.safetensors` model file, so this is a parse-time DoS.

## Fix

Before slicing, validate the offsets are non-negative, ordered, and within the data section:

```go
if tensorOffset < 0 || tensorEnd < tensorOffset || tensorEnd > int64(len(mr.mmapBuf)) {
    return nil, errors.Errorf("tensor %q data offsets [%d:%d] out of range for %d-byte data section", ...)
}
```

Applied to both `ReadTensor` and the iterator.

## Testing

Added `TestReadTensorRejectsOutOfRangeOffsets` (beyond-buffer and negative offsets): both now return an "out of range" error instead of panicking. Verified RED→GREEN (reverting the guard reproduces the slice-out-of-range panic). The `models/safetensors` suite passes; `gofmt` and `go vet` clean.

---

Note: happy to sign a CLA if the project requires one — just let me know.
